### PR TITLE
Add more i18n functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ __(__i18n_b357e65520993c7fdce6b04ccf237a3f88a0f77dbfdca784f5d646b5b59e498c);"#
         nested_code,
         r#"const foo = bar(__("other_translation"));"#,
         r#"import { __i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df } from "../../.cache/translations.i18n?dev";
-const foo = bar(__(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df || "other_translation"));"#
+        const foo = bar(__(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df || "other_translation"));"#
     );
 
     test!(
@@ -297,9 +297,9 @@ const foo = bar(__(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce
         icu_code,
         r#"const foo = __icu("Buy n pieces", { numberOfProducts: p.minAmount });"#,
         r#"import { __i18n_d1b6589d9678069ddad863d441fe188e5362130e5be23215a5ff66458ef94441 } from "../../.cache/translations.i18n?dev";
-const foo = __icu(__i18n_d1b6589d9678069ddad863d441fe188e5362130e5be23215a5ff66458ef94441 || "Buy n pieces", {
-    numberOfProducts: p.minAmount
-});"#
+        const foo = __icu(__i18n_d1b6589d9678069ddad863d441fe188e5362130e5be23215a5ff66458ef94441 || "Buy n pieces", {
+            numberOfProducts: p.minAmount
+        });"#
     );
 
     test!(
@@ -308,7 +308,7 @@ const foo = __icu(__i18n_d1b6589d9678069ddad863d441fe188e5362130e5be23215a5ff664
         markdown_code,
         r#"const foo = __md("other_translation");"#,
         r#"import { __i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df } from "../../.cache/translations.i18n?dev";
-const foo = __md(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df || "other_translation");"#
+        const foo = __md(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df || "other_translation");"#
     );
 
     test!(
@@ -317,16 +317,19 @@ const foo = __md(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e
         by_language_code,
         r#"const foo = __byLanguage("other_translation");"#,
         r#"import { __i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df } from "../../.cache/translations.i18n?dev";
-const foo = __byLanguage(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df || "other_translation");"#
+        const foo = __byLanguage(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df || "other_translation");"#
     );
 
     test!(
         Default::default(),
         |_| transform_visitor(Environment::Development),
         icu_by_language,
-        r#"const foo = __icuByLanguage("other_translation");"#,
-        r#"import { __i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df } from "../../.cache/translations.i18n?dev";
-const foo = __icuByLanguage(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df || "other_translation");"#
+        r#"const foo = __icuByLanguage("Pluralized items ordered", language, { category, stockCount });"#,
+        r#"import { __i18n_5dec8611ff95ef5ade67844d5a0b16a7c2020762363f0231d8bf4ba7aeca7474 } from "../../.cache/translations.i18n?dev";
+        const foo = __icuByLanguage(__i18n_5dec8611ff95ef5ade67844d5a0b16a7c2020762363f0231d8bf4ba7aeca7474 || "Pluralized items ordered", language, {
+            category,
+            stockCount
+        });"#
     );
 
     test!(
@@ -335,7 +338,7 @@ const foo = __icuByLanguage(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d0382643
         md_by_language,
         r#"const foo = __mdByLanguage("other_translation");"#,
         r#"import { __i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df } from "../../.cache/translations.i18n?dev";
-const foo = __mdByLanguage(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df || "other_translation");"#
+        const foo = __mdByLanguage(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df || "other_translation");"#
     );
 
     test!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,19 +141,21 @@ impl VisitMut for TransformVisitor {
         if let Callee::Expr(expr) = &mut call_expr.callee {
             if let Expr::Ident(id) = &mut **expr {
                 match id.sym.as_ref() {
-                   "__" | "__icu" | "__md" | "__byLanguage" | "__icuByLanguage" | "__mdByLanguage" => {
+                    "__" | "__icu" | "__md" | "__byLanguage" | "__icuByLanguage"
+                    | "__mdByLanguage" => {
                         let first_argument = call_expr.args.first_mut().unwrap_or_else(|| panic!(
                             r#"Translation function requires an argument e.g. __("Hello World") in {}"#,
                             self.context.filename));
-    
+
                         if let Expr::Lit(Lit::Str(translation_key)) = &mut *first_argument.expr {
-                            let variable_name = helpers::generate_variable_name(&translation_key.value);
+                            let variable_name =
+                                helpers::generate_variable_name(&translation_key.value);
                             let variable_identifier = Expr::Ident(Ident {
                                 span: DUMMY_SP,
                                 sym: variable_name.clone().into(),
                                 optional: false,
                             });
-    
+
                             let argument = match self.context.env_name {
                                 // For development add fallback on the key for unknown translations
                                 // __(__i18n_Hello || "Hello")
@@ -167,12 +169,12 @@ impl VisitMut for TransformVisitor {
                                 // __(__i18n_Hello)
                                 _ => variable_identifier,
                             };
-    
+
                             call_expr.args[0] = ExprOrSpread {
                                 spread: None,
                                 expr: Box::new(argument),
                             };
-    
+
                             // Remember variable name to generate import later
                             self.import_variables.insert(variable_name);
                         } else {
@@ -182,7 +184,7 @@ impl VisitMut for TransformVisitor {
                             )
                         }
                     }
-                    _ => {},
+                    _ => {}
                 }
             }
         }
@@ -293,9 +295,11 @@ const foo = bar(__(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce
         Default::default(),
         |_| transform_visitor(Environment::Development),
         icu_code,
-        r#"const foo = __icu("other_translation");"#,
-        r#"import { __i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df } from "../../.cache/translations.i18n?dev";
-const foo = __icu(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437c16da0ce2e061479df || "other_translation");"#
+        r#"const foo = __icu("Buy n pieces", { numberOfProducts: p.minAmount });"#,
+        r#"import { __i18n_d1b6589d9678069ddad863d441fe188e5362130e5be23215a5ff66458ef94441 } from "../../.cache/translations.i18n?dev";
+const foo = __icu(__i18n_d1b6589d9678069ddad863d441fe188e5362130e5be23215a5ff66458ef94441 || "Buy n pieces", {
+    numberOfProducts: p.minAmount
+});"#
     );
 
     test!(
@@ -341,5 +345,4 @@ const foo = __mdByLanguage(__i18n_c4622ceee64504cbc2c5b05ecb9e66c4235c6d03826437
         r#"const foo = "Hello, world!";"#,
         r#"const foo = "Hello, world!";"#
     );
-    
 }


### PR DESCRIPTION
this pull request adds support for additional utility functions for translations. 

previously, the plugin was designed to transform only a function named `__`, but as the project progressed, it became evident that there is a need for more diverse translation utilities to cover various use cases, such as ICU and Markdown translations. 

this PR covers the following new utility functions:

- `__`: The original utility function for translations.
- `__icu`: A new utility function that supports ICU (International Components for Unicode) formatted translations.
- `__md`: A new utility function that supports translations containing Markdown formatting.
- `__byLanguage`: A new utility function that allows translation selection based on the desired language.
- `__icuByLanguage`: A new utility function that combines ICU formatting and language-based translation selection.
- `__mdByLanguage`: A new utility function that combines Markdown formatting and language-based translation selection.